### PR TITLE
fix: Add scripts and files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "bin": {
     "create-gnome-extension": "index.js"
   },
+  "scripts": {},
+  "files": [
+    "template",
+    "index.js"
+  ],
   "type": "module",
   "keywords": [
     "GNOME",


### PR DESCRIPTION
If the scripts fields is missing, you'll get a warning when trying to publish the package. So let's add an empty scripts field to avoid that.

Also, let's add the files field to specify which files should be included in the package. This way, we can avoid including unnecessary files like tooling/config files etc.