### PR TITLE
ci: Fix setup-node version

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts"
+          node-version: "20.x"
       - name: Create tarball
         run: npm pack
       - name: Extract version number


### PR DESCRIPTION
I guess I was misunderstanding how to add the version of node. I thought `lts` would work based on this https://github.com/actions/setup-node?tab=readme-ov-file#usage ... but it seems like it doesn't.