### PR TITLE
Fix TypeScript decorators not transpiling

### DIFF
--- a/.github/workflows/link-and-merge-pr.yml
+++ b/.github/workflows/link-and-merge-pr.yml
@@ -37,7 +37,7 @@ jobs:
             last_line_is_trailer = lines and re.search(b"^\w+: ", lines[-1]) is not None
 
             if not lines:
-              return trailer
+              return b"\n" + trailer
             elif last_line_is_trailer:
               return message.strip() + b"\n" + trailer
             else:

--- a/index.js
+++ b/index.js
@@ -378,7 +378,11 @@ async function configureTypes({
                     ),
                 );
             } else {
-                tsconfigJson['compilerOptions']['isolatedModules'] = undefined;
+                packageJson.devDependencies['esbuild'] = undefined;
+                packageJson.devDependencies['esbuild-plugin-tsc'] = undefined;
+                tsconfigJson.compilerOptions['isolatedModules'] = undefined;
+                tsconfigJson.compilerOptions['experimentalDecorators'] =
+                    undefined;
             }
 
             await fs.writeFile(
@@ -605,7 +609,7 @@ async function queryUserFor(option, partialProjectInfo) {
 
         case 'use-esbuild':
             console.log(
-                `${AnsiEscSeq.FAINT}esbuild allows for faster builds but doesn't check your code during the build process. So you will need to rely on your editor's type checking or use \`npm run check:types\` manually. esbuild also comes with some caveats. Visit https://esbuild.github.io/content-types/#typescript-caveats for more information.${AnsiEscSeq.RESET}`,
+                `${AnsiEscSeq.FAINT}esbuild allows for faster builds but doesn't check your code during the build process. So you will need to rely on your editor's type checking or use \`npm run check:types\` manually. esbuild also comes with some caveats. E. g. esbuild doesn't support stage 3 decorators, so you will use TypeScripts experimental stage 2 decorators. Visit https://esbuild.github.io/content-types/#typescript-caveats for more.${AnsiEscSeq.RESET}`,
             );
 
             return await promptYesOrNo('Add esbuild?', {

--- a/template/scripts/esbuild.js
+++ b/template/scripts/esbuild.js
@@ -1,17 +1,10 @@
 #!/usr/bin/env node
 
 import * as esbuild from 'esbuild';
-import esbuildPluginTsc from 'esbuild-plugin-tsc';
 
 esbuild.build({
     entryPoints: ['src/**/*.ts'],
     outdir: 'dist/',
     platform: 'neutral',
-    plugins: [
-        // esbuild doesn't support TypeScript's stage 3 decorators, so we need
-        // this plugin to use `tsc` to transpile the files which use them. Or
-        // we could use the stage 2 decorators via the `experimentalDecorators`
-        // option, which is supported by esbuild... but that seems worse.
-        esbuildPluginTsc(),
-    ],
+    format: 'esm'
 });

--- a/template/template.ts/tsconfig.json
+++ b/template/template.ts/tsconfig.json
@@ -1,13 +1,17 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2022",
     "module": "nodenext",
     "rootDir": "./src",
     "moduleResolution": "nodenext",
     "outDir": "./dist",
     "isolatedModules": true,
+    "experimentalDecorators": true,
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["ambient.d.ts", "src/**/*.ts"]
+  "include": [
+    "ambient.d.ts",
+    "src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
> I thought I've tested that the stage 3 decorators work with esbuild when
using the plugin but apparently I didn't because trying it out now, the
decorators aren't transpiled at all... so fall back to stage 2 decorators
when using esbuild.
> 
> Also set the target for TypeScript to es2022, otherwise decorators won't
get transpiled either.